### PR TITLE
remove unnecessary remote files in mod.ts

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "imports": {
     "lume/": "https://deno.land/x/lume@v2.5.0/",
     "blog/": "https://deno.land/x/lume_theme_simple_blog@v0.15.10/",
-    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.9.1/"
+    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.9.2/"
   },
   "tasks": {
     "lume": "echo \"import 'lume/cli.ts'\" | deno run -A -",

--- a/deno.lock
+++ b/deno.lock
@@ -1348,6 +1348,7 @@
     "https://deno.land/x/lume_theme_simple_blog@v0.15.10/src/archive_result.page.js#1737442687900": "0b40382fb881a044a2fffa75927c979c4403c472a7ac390c81bd51907d3e28c7",
     "https://deno.land/x/lume_theme_simple_blog@v0.15.10/src/archive_result.page.js#1737454259268": "0b40382fb881a044a2fffa75927c979c4403c472a7ac390c81bd51907d3e28c7",
     "https://deno.land/x/lume_theme_simple_blog@v0.15.10/src/archive_result.page.js#1737481395890": "0b40382fb881a044a2fffa75927c979c4403c472a7ac390c81bd51907d3e28c7",
+    "https://deno.land/x/lume_theme_simple_blog@v0.15.10/src/archive_result.page.js#1737483103163": "0b40382fb881a044a2fffa75927c979c4403c472a7ac390c81bd51907d3e28c7",
     "https://deno.land/x/lume_theme_simple_blog@v0.15.8/_cms.ts": "2ec61f55969bd76c2183cc2268021107d8394d2c9754e61becb4fa14ddf89435",
     "https://deno.land/x/lume_theme_simple_blog@v0.15.8/mod.ts": "18cc116c75ad85dc3e86407487f5555ac8b051b26ba90dd7f78cc5f724d6cff2",
     "https://deno.land/x/lume_theme_simple_blog@v0.15.8/plugins.ts": "a9748fff373bd694776d7bb1888023e25728bd61c7ffd34201d851f8756d5526",

--- a/mod.ts
+++ b/mod.ts
@@ -11,32 +11,24 @@ export default function (options: Partial<Options> = {}) {
 
     // Add remote files
     const files = [
-      "_includes/css/fonts.css",
-      "_includes/css/navbar.css",
+      "_includes/css/ds.css",
       "_includes/css/page.css",
       "_includes/css/post-list.css",
       "_includes/css/post.css",
-      "_includes/css/reset.css",
-      "_includes/css/badge.css",
-      "_includes/css/variables.css",
-      "_includes/css/search.css",
       "_includes/layouts/archive_result.vto",
       "_includes/layouts/archive.vto",
       "_includes/layouts/base.vto",
       "_includes/layouts/page.vto",
       "_includes/layouts/post.vto",
       "_includes/templates/post-details.vto",
-      "_includes/templates/post-list.vto",
       "posts/_data.yml",
       "_data.yml",
       "_data/i18n.yml",
       "404.md",
-      "archive_result.page.js",
       "archive.page.js",
       "index.vto",
       "styles.css",
       "favicon.png",
-      "js/main.js",
     ];
 
     for (const file of files) {


### PR DESCRIPTION
Resolving new error since v2 when installing with: 

`deno run -A https://lume.land/init.ts --theme=xeo`

```
Task build deno task lume
Task lume echo "import 'lume/cli.ts'" | deno run -A -
Loading config file file:///Users/[…]/_config.ts
error: Uncaught (in promise) TypeError: Module not found "https://deno.land/x/xeo@v2.0.0/archive_result.page.js".
  const mod = await import(specifier);
              ^
    at async module (https://deno.land/x/lume@v2.5.0/core/loaders/module.ts:14:15)
    at async Source.#build (https://deno.land/x/lume@v2.5.0/core/source.ts:357:28)
    at async Source.build (https://deno.land/x/lume@v2.5.0/core/source.ts:140:5)
    at async Site.build (https://deno.land/x/lume@v2.5.0/core/site.ts:524:36)
    at async buildSite (https://deno.land/x/lume@v2.5.0/cli/utils.ts:48:3)
```

See https://github.com/lumeland/themes/pull/3#issuecomment-2605418213