### PR TITLE
include post-list template for archive.vto

### DIFF
--- a/_includes/templates/post-list.vto
+++ b/_includes/templates/post-list.vto
@@ -1,0 +1,18 @@
+<ul class="postList">
+  {{ for post of postslist }}
+  <li class="post">
+    <h2 class="post-title">
+      <a href="{{ post.url }}" {{ if post.url == url }} aria-current="page"{{ /if }}>
+        {{ post.title || post.url }}
+      </a>
+    </h2>
+
+    {{ include "templates/post-details.vto" {
+      date: post.date,
+      tags: post.tags,
+      author: post.author,
+      readingInfo: post.readingInfo
+    } }}
+  </li>
+  {{ /for }}
+</ul>

--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "imports": {
     "lume/": "https://deno.land/x/lume@v2.5.0/",
     "blog/": "https://deno.land/x/lume_theme_simple_blog@v0.15.10/",
-    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.9.2/"
+    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@v0.9.2/"
   },
   "tasks": {
     "lume": "echo \"import 'lume/cli.ts'\" | deno run -A -",

--- a/deno.lock
+++ b/deno.lock
@@ -1349,6 +1349,7 @@
     "https://deno.land/x/lume_theme_simple_blog@v0.15.10/src/archive_result.page.js#1737454259268": "0b40382fb881a044a2fffa75927c979c4403c472a7ac390c81bd51907d3e28c7",
     "https://deno.land/x/lume_theme_simple_blog@v0.15.10/src/archive_result.page.js#1737481395890": "0b40382fb881a044a2fffa75927c979c4403c472a7ac390c81bd51907d3e28c7",
     "https://deno.land/x/lume_theme_simple_blog@v0.15.10/src/archive_result.page.js#1737483103163": "0b40382fb881a044a2fffa75927c979c4403c472a7ac390c81bd51907d3e28c7",
+    "https://deno.land/x/lume_theme_simple_blog@v0.15.10/src/archive_result.page.js#1737484294551": "0b40382fb881a044a2fffa75927c979c4403c472a7ac390c81bd51907d3e28c7",
     "https://deno.land/x/lume_theme_simple_blog@v0.15.8/_cms.ts": "2ec61f55969bd76c2183cc2268021107d8394d2c9754e61becb4fa14ddf89435",
     "https://deno.land/x/lume_theme_simple_blog@v0.15.8/mod.ts": "18cc116c75ad85dc3e86407487f5555ac8b051b26ba90dd7f78cc5f724d6cff2",
     "https://deno.land/x/lume_theme_simple_blog@v0.15.8/plugins.ts": "a9748fff373bd694776d7bb1888023e25728bd61c7ffd34201d851f8756d5526",

--- a/mod.ts
+++ b/mod.ts
@@ -21,6 +21,7 @@ export default function (options: Partial<Options> = {}) {
       "_includes/layouts/page.vto",
       "_includes/layouts/post.vto",
       "_includes/templates/post-details.vto",
+      "_includes/templates/post-list.vto",
       "posts/_data.yml",
       "_data.yml",
       "_data/i18n.yml",


### PR DESCRIPTION
Upshot is anything inside `{{ include` needs to be copied into the child theme whether or not it it is being replaced.

See https://github.com/lumeland/themes/pull/3#issuecomment-2605468232