### PR TITLE
include navbar for styles.css

### DIFF
--- a/_includes/css/navbar.css
+++ b/_includes/css/navbar.css
@@ -1,0 +1,35 @@
+.navbar {
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: 1rem;
+  row-gap: 1rem;
+  justify-content: space-between;
+  padding: 2rem min(5vw, 5rem);
+  align-items: center;
+}
+
+.navbar-links {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: 1.5rem;
+  font: var(--font-ui-bold);
+  align-items: center;
+
+  & [aria-current="page"] {
+    text-decoration: none;
+  }
+}
+
+.navbar-search {
+  padding: 0 1em;
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+}
+
+.navbar-home {
+  text-decoration: none;
+}

--- a/mod.ts
+++ b/mod.ts
@@ -12,6 +12,7 @@ export default function (options: Partial<Options> = {}) {
     // Add remote files
     const files = [
       "_includes/css/ds.css",
+      "_includes/css/navbar.css",
       "_includes/css/page.css",
       "_includes/css/post-list.css",
       "_includes/css/post.css",


### PR DESCRIPTION
See https://github.com/lumeland/themes/pull/3#issuecomment-2605456047

```
Task build deno task lume
Task lume echo "import 'lume/cli.ts'" | deno run -A -
Loading config file file:///Users/[…]/_config.ts
error: Uncaught (in promise) Error: File /_includes/css/navbar.css not found
        throw new Error(`File ${file} not found`);
              ^
    at Object.load (https://deno.land/x/lume@v2.5.0/plugins/postcss.ts:137:15)
    at eventLoopTick (ext:core/01_core.js:175:7)
    at async loadImportContent (file:///Users/r/Library/Caches/deno/npm/registry.npmjs.org/postcss-import/16.1.0/lib/parse-styles.js:168:19)
    at async Promise.all (index 0)
    at async resolveImportId (file:///Users/r/Library/Caches/deno/npm/registry.npmjs.org/postcss-import/16.1.0/lib/parse-styles.js:124:27)
    at async parseStyles (file:///Users/r/Library/Caches/deno/npm/registry.npmjs.org/postcss-import/16.1.0/lib/parse-styles.js:32:5)
    at async Object.Once (file:///Users/r/Library/Caches/deno/npm/registry.npmjs.org/postcss-import/16.1.0/index.js:51:22)
    at async LazyResult.runAsync (file:///Users/r/Library/Caches/deno/npm/registry.npmjs.org/postcss/8.4.49/lib/lazy-result.js:261:11)
    at async postCss (https://deno.land/x/lume@v2.5.0/plugins/postcss.ts:96:22)
    at async Promise.all (index 0)
```