### PR TITLE
patch local post.css w/ post-details sep fix, bump sb

### DIFF
--- a/_includes/css/post.css
+++ b/_includes/css/post.css
@@ -23,7 +23,7 @@
     margin: 0;
   }
 
-  & p:nth-child(-n+2)::after {
+  & p::after {
     content: "•";
     padding-left: 0.5em;
     align-self: stretch;
@@ -31,6 +31,10 @@
 
   & p:last-of-type {
     margin-right: 0.5em;
+    
+    &::after {
+      display: none;
+    }
   }
 
   & a {

--- a/deno.json
+++ b/deno.json
@@ -1,8 +1,8 @@
 {
   "imports": {
     "lume/": "https://deno.land/x/lume@v2.5.3/",
-    "blog/": "https://deno.land/x/lume_theme_simple_blog@v0.15.10/",
-    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.11.3/",
+    "blog/": "https://deno.land/x/lume_theme_simple_blog@v0.15.11/",
+    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.11.4/",
     "lume/jsx-runtime": "https://deno.land/x/ssx@v0.1.8/jsx-runtime.ts"
   },
   "tasks": {

--- a/deno.lock
+++ b/deno.lock
@@ -1299,6 +1299,8 @@
     "https://deno.land/x/lume_theme_simple_blog@v0.15.10/src/archive_result.page.js#1745351381131": "0b40382fb881a044a2fffa75927c979c4403c472a7ac390c81bd51907d3e28c7",
     "https://deno.land/x/lume_theme_simple_blog@v0.15.10/src/archive_result.page.js#1745351787770": "0b40382fb881a044a2fffa75927c979c4403c472a7ac390c81bd51907d3e28c7",
     "https://deno.land/x/lume_theme_simple_blog@v0.15.10/src/archive_result.page.js#1745351997002": "0b40382fb881a044a2fffa75927c979c4403c472a7ac390c81bd51907d3e28c7",
+    "https://deno.land/x/lume_theme_simple_blog@v0.15.10/src/archive_result.page.js#1745421154147": "0b40382fb881a044a2fffa75927c979c4403c472a7ac390c81bd51907d3e28c7",
+    "https://deno.land/x/lume_theme_simple_blog@v0.15.10/src/archive_result.page.js#1745421405312": "0b40382fb881a044a2fffa75927c979c4403c472a7ac390c81bd51907d3e28c7",
     "https://deno.land/x/ssx@v0.1.8/css.ts": "6756e74b96e3694631745ce12f80f4eb89c88940f44fbd97e4b676811bbc225c",
     "https://deno.land/x/ssx@v0.1.8/html.ts": "26185b76f311467f1e2f93131ebb6f48b709cf6e9eefd254d95260ccaa0e1e6b",
     "https://deno.land/x/ssx@v0.1.8/jsx-runtime.ts": "79b5c6b482b43b84bc07ef5fe0d010572de5cffa94a6eecf9aaff6f51d102df9",


### PR DESCRIPTION
see https://github.com/lumeland/theme-simple-blog/commit/9fb9f6d44fd5dbfd59b55aea9b408d701ebc3330
+ https://github.com/famebot/xeo/pull/13#issuecomment-2824687828

bumped Simple Blog here but still had to update local `post.css` with `::after` fix since we override it.