### PR TITLE
balance spacing before .post-details time and after separating middot

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "imports": {
     "lume/": "https://deno.land/x/lume@v2.5.3/",
     "blog/": "https://deno.land/x/lume_theme_simple_blog@v0.15.11/",
-    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.11.4/",
+    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.11.5/",
     "lume/jsx-runtime": "https://deno.land/x/ssx@v0.1.8/jsx-runtime.ts"
   },
   "tasks": {

--- a/deno.lock
+++ b/deno.lock
@@ -1301,6 +1301,7 @@
     "https://deno.land/x/lume_theme_simple_blog@v0.15.10/src/archive_result.page.js#1745351997002": "0b40382fb881a044a2fffa75927c979c4403c472a7ac390c81bd51907d3e28c7",
     "https://deno.land/x/lume_theme_simple_blog@v0.15.10/src/archive_result.page.js#1745421154147": "0b40382fb881a044a2fffa75927c979c4403c472a7ac390c81bd51907d3e28c7",
     "https://deno.land/x/lume_theme_simple_blog@v0.15.10/src/archive_result.page.js#1745421405312": "0b40382fb881a044a2fffa75927c979c4403c472a7ac390c81bd51907d3e28c7",
+    "https://deno.land/x/lume_theme_simple_blog@v0.15.10/src/archive_result.page.js#1745900974149": "0b40382fb881a044a2fffa75927c979c4403c472a7ac390c81bd51907d3e28c7",
     "https://deno.land/x/ssx@v0.1.8/css.ts": "6756e74b96e3694631745ce12f80f4eb89c88940f44fbd97e4b676811bbc225c",
     "https://deno.land/x/ssx@v0.1.8/html.ts": "26185b76f311467f1e2f93131ebb6f48b709cf6e9eefd254d95260ccaa0e1e6b",
     "https://deno.land/x/ssx@v0.1.8/jsx-runtime.ts": "79b5c6b482b43b84bc07ef5fe0d010572de5cffa94a6eecf9aaff6f51d102df9",

--- a/styles.css
+++ b/styles.css
@@ -145,3 +145,10 @@ https://github.com/lumeland/ds/blob/v0.5.2/src/components/body.css#L34
     color: currentColor;
   }
 }
+
+/*
+balance spacing before and after separating middot •
+*/
+.post-details time {
+  margin-inline-end: -0.59375ch;
+}


### PR DESCRIPTION
not sure why, but .post-details time has 0.40625ch extra space after it? any thoughts @oscarotero?