### PR TITLE
update deps + tasks

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,20 +1,33 @@
 {
   "imports": {
-    "lume/": "https://deno.land/x/lume@v3.0.6/",
+    "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/",
     "blog/": "https://deno.land/x/lume_theme_simple_blog@v1.16.2/",
-    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.12.5/",
-    "lume/jsx-runtime": "https://deno.land/x/ssx@v0.1.12/jsx-runtime.ts"
+    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.14.2/",
+    "lume/jsx-runtime": "https://cdn.jsdelivr.net/gh/oscarotero/ssx@0.1.12/jsx-runtime.ts"
   },
   "tasks": {
-    "lume": "echo \"import 'lume/cli.ts'\" | deno run -A -",
+    "lume": {
+      "description": "Run Lume command",
+      "command": "deno run -P=lume lume/cli.ts"
+    },
     "prod": "deno task lume --location=https://xeo.land",
-    "build": "deno task lume",
-    "serve": "deno task lume -s",
+    "build": {
+      "description": "Build the site for production",
+      "command": "deno task lume"
+    },
+    "serve": {
+      "description": "Run and serve the site for development",
+      "command": "deno task lume -s"
+    },
     "d": "deno task serve",
-    "cms": "deno task lume cms",
-    "lup": "deno task lume upgrade",
-    "lupd": "deno task lume upgrade --dev",
-    "up": "deno run -A --quiet 'https://deno.land/x/nudd@v0.2.10/cli.ts' update deno.json"
+    "lup": {
+      "description": "Update Lume, for latest, add: --dev",
+      "command": "deno task lume upgrade"
+    },
+    "up": {
+      "description": "Upgrade dependencies, including Lume",
+      "command": "deno run -A --quiet 'https://deno.land/x/nudd@v0.2.10/cli.ts' update deno.json"
+    }
   },
   "compilerOptions": {
     "types": [
@@ -30,10 +43,13 @@
     "rules": {
       "tags": [
         "recommended"
+      ],
+      "exclude": [
+        "no-import-prefix"
       ]
     },
     "plugins": [
-      "https://deno.land/x/lume@v3.0.6/lint.ts"
+      "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/lint.ts"
     ]
   },
   "fmt": {
@@ -44,5 +60,31 @@
   "unstable": [
     "temporal",
     "fmt-component"
-  ]
+  ],
+  "permissions": {
+    "lume": {
+      "read": true,
+      "write": [
+        "./"
+      ],
+      "import": [
+        "cdn.jsdelivr.net:443",
+        "jsr.io:443",
+        "deno.land:443",
+        "esm.sh:443"
+      ],
+      "net": [
+        "0.0.0.0",
+        "jsr.io:443",
+        "cdn.jsdelivr.net:443",
+        "data.jsdelivr.com:443",
+        "registry.npmjs.org:443"
+      ],
+      "env": true,
+      "run": true,
+      "ffi": true,
+      "sys": true
+    }
+  },
+  "lock": false
 }

--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,7 @@
   "tasks": {
     "lume": {
       "description": "Run Lume command",
-      "command": "deno run -P=lume lume/cli.ts"
+      "command": "deno run --allow-net=fonts.googleapis.com:443,cdn.jsdelivr.net:443,0.0.0.0:3000 -P=lume lume/cli.ts"
     },
     "prod": "deno task lume --location=https://xeo.land",
     "build": {

--- a/deno.json
+++ b/deno.json
@@ -1,14 +1,14 @@
 {
   "imports": {
-    "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/",
+    "lume/": "https://deno.land/x/lume@v3.1.2/",
     "blog/": "https://deno.land/x/lume_theme_simple_blog@v1.16.2/",
     "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.14.2/",
-    "lume/jsx-runtime": "https://cdn.jsdelivr.net/gh/oscarotero/ssx@0.1.12/jsx-runtime.ts"
+    "lume/jsx-runtime": "https://deno.land/x/ssx@v0.1.12/jsx-runtime.ts"
   },
   "tasks": {
     "lume": {
       "description": "Run Lume command",
-      "command": "deno run --allow-net=fonts.googleapis.com:443,cdn.jsdelivr.net:443,0.0.0.0:3000 -P=lume lume/cli.ts"
+      "command": "echo \"import 'lume/cli.ts'\" | deno run -A -"
     },
     "prod": "deno task lume --location=https://xeo.land",
     "build": {
@@ -26,7 +26,7 @@
     },
     "up": {
       "description": "Upgrade dependencies, including Lume",
-      "command": "deno run -A --quiet 'https://deno.land/x/nudd@v0.2.10/cli.ts' update deno.json"
+      "command": "deno run -A --quiet 'https://deno.land/x/nudd@v0.2.10/cli.ts' update plugins.ts deno.json"
     }
   },
   "compilerOptions": {

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,5 +2,5 @@
   publish = "_site"
   command = """
   curl -fsSL https://deno.land/install.sh | sh && \
-  /opt/buildhome/.deno/bin/deno task prod --allow-net fonts.googleapis.com:443 \
+  /opt/buildhome/.deno/bin/deno task prod --allow-net=fonts.googleapis.com:443 \
 """

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,5 +2,5 @@
   publish = "_site"
   command = """
   curl -fsSL https://deno.land/install.sh | sh && \
-  /opt/buildhome/.deno/bin/deno task prod --allow-net=fonts.googleapis.com:443 \
+  /opt/buildhome/.deno/bin/deno task prod \
 """

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,5 +2,5 @@
   publish = "_site"
   command = """
   curl -fsSL https://deno.land/install.sh | sh && \
-  /opt/buildhome/.deno/bin/deno task prod \
+  /opt/buildhome/.deno/bin/deno task prod --allow-net fonts.googleapis.com:443 \
 """

--- a/plugins.ts
+++ b/plugins.ts
@@ -1,5 +1,5 @@
-import baseBlog from "https://deno.land/x/lume_theme_simple_blog@v0.16.0/mod.ts";
-import type { Options as BaseBlogOptions } from "https://deno.land/x/lume_theme_simple_blog@v0.16.0/mod.ts";
+import baseBlog from "https://deno.land/x/lume_theme_simple_blog@v1.16.2/mod.ts";
+import type { Options as BaseBlogOptions } from "https://deno.land/x/lume_theme_simple_blog@v1.16.2/mod.ts";
 import favicon from "lume/plugins/favicon.ts";
 import googleFonts from "lume/plugins/google_fonts.ts";
 import { merge } from "lume/core/utils/object.ts";


### PR DESCRIPTION
- Lume version 3.1.2   
  Updated: 
  https://deno.land/x/lume@v3.0.6/ v3.0.6 -> v3.1.2 
  https://cdn.jsdelivr.net/gh/lumeland/cms@0.12.5/ 0.12.5 -> 0.14.2

- Simple Blog 1.16.2   
  https://deno.land/x/lume_theme_simple_blog@v0.16.0/ v0.16.0 -> v1.16.2

- rm `cms` task, runs automatically now https://lume.land/cms/#run-in-localhost

- describe `up` + `lup` tasks