### PR TITLE
specify archive bodyClass

### DIFF
--- a/_includes/layouts/archive.vto
+++ b/_includes/layouts/archive.vto
@@ -1,6 +1,6 @@
 ---
 layout: layouts/base.vto
-bodyClass: body-tag
+bodyClass: body-archive
 ---
 
 <main class="{{ it.bodyClass }}">

--- a/deno.json
+++ b/deno.json
@@ -1,14 +1,14 @@
 {
   "imports": {
-    "lume/": "https://deno.land/x/lume@v3.1.2/",
+    "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/",
     "blog/": "https://deno.land/x/lume_theme_simple_blog@v1.16.2/",
     "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.14.2/",
-    "lume/jsx-runtime": "https://deno.land/x/ssx@v0.1.12/jsx-runtime.ts"
+    "lume/jsx-runtime": "https://cdn.jsdelivr.net/gh/oscarotero/ssx@0.1.12/jsx-runtime.ts"
   },
   "tasks": {
     "lume": {
       "description": "Run Lume command",
-      "command": "echo \"import 'lume/cli.ts'\" | deno run -A -"
+      "command": "deno run -A lume/cli.ts"
     },
     "prod": "deno task lume --location=https://xeo.land",
     "build": {


### PR DESCRIPTION
- specify archive bodyClass
  `.body-archive` styling hook

- bare specifier in lume task and use jsdelivr

  > Deno can run now bare specifiers and it's automatically resolved using the import map (previously this wasn't possible, hence the echo thing). 
https://lume.land/blog/posts/lume-3-1-0/#lume-task-uses-bare-specifier

  > This makes possible the use of permissions (in order to make the build more secure) and other features related 
with stdin in future Lume versions.

  > jsdelivr is the recommended way. Lume was moved to JsDelivr
  > https://lume.land/blog/posts/lume-3-1-0/#lume-is-moving-to-jsdelivr

  > and this will make easier the creation of themes because you can use glob patterns instead of configuring all files manually
  > https://lume.land/blog/posts/lume-3-1-0/#create-themes-is-now-easier