### PR TITLE
Filesystem titles: sentence case, use Extract date + basename

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -3,7 +3,21 @@ import blog from "./mod.ts";
 
 const site = lume();
 
+/*
+1. Use Simple Blog theme as parent theme.
+2. Create preprocessor to ensure all pages have a title, so we do not need to generate
+   it in the templates.
+*/
 site
-  .use(blog());
+  .use(blog())
+  .preprocess([".md"], (pages) => {
+    for (const page of pages) {
+      if (!page.data.title) {
+        page.data.title = page.data.basename
+          .replaceAll(/-(?!\d)/g, ` `) // remove hyphens unless followed by 0-9
+          .replace(/\b\w/, (char) => char.toUpperCase()); // sentence case
+      } // for title case use /\b\w/g
+    }
+  });
 
 export default site;

--- a/_includes/layouts/base.vto
+++ b/_includes/layouts/base.vto
@@ -4,17 +4,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    {{ if !it.title && metas.title == "=title" }}
-      <title>
-        {{-
-          basename
-          |> replaceAll(/-(?!\d)/g, ` `)
-          |> replace(/\b\w/, (char) => char.toUpperCase())
-        }} - {{ metas.site -}}
-      </title>
-    {{ else }}
-      <title>{{- it.title || metas.title }} - {{ metas.site -}}</title>
-    {{ /if }}
+    <title>{{ it.title || metas.title }} - {{ metas.site }}</title>
     <link rel="stylesheet" href="/color-options.css">
     <link rel="stylesheet" href="/styles.css">
     <link

--- a/_includes/layouts/base.vto
+++ b/_includes/layouts/base.vto
@@ -6,12 +6,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     {{ if !it.title && metas.title == "=title" }}
       <title>
-        {{ url.substr(1, url.length - 2) |> replaceAll(/-(?!\d)/g, ` `) }} - {{
-          metas.site
-        }}
+        {{-
+          basename
+          |> replaceAll(/-(?!\d)/g, ` `)
+          |> replace(/\b\w/, (char) => char.toUpperCase())
+        }} - {{ metas.site -}}
       </title>
     {{ else }}
-      <title>{{ it.title || metas.title }} - {{ metas.site }}</title>
+      <title>{{- it.title || metas.title }} - {{ metas.site -}}</title>
     {{ /if }}
     <link rel="stylesheet" href="/color-options.css">
     <link rel="stylesheet" href="/styles.css">

--- a/_includes/layouts/post.vto
+++ b/_includes/layouts/post.vto
@@ -11,13 +11,7 @@ bodyClass: body-post
     data-pagefind-index-attrs="data-title"
   >
     <header class="post-header">
-      <h1 class="post-title">
-        {{-
-          title || basename
-          |> replaceAll(/-(?!\d)/g, ` `)
-          |> replace(/\b\w/, (char) => char.toUpperCase())
-        -}}
-      </h1>
+      <h1 class="post-title">{{ title }}</h1>
 
       {{ include "templates/post-details.vto" }}
     </header>

--- a/_includes/layouts/post.vto
+++ b/_includes/layouts/post.vto
@@ -11,7 +11,13 @@ bodyClass: body-post
     data-pagefind-index-attrs="data-title"
   >
     <header class="post-header">
-      <h1 class="post-title">{{ title }}</h1>
+      <h1 class="post-title">
+        {{-
+          title || basename
+          |> replaceAll(/-(?!\d)/g, ` `)
+          |> replace(/\b\w/, (char) => char.toUpperCase())
+        -}}
+      </h1>
 
       {{ include "templates/post-details.vto" }}
     </header>

--- a/_includes/templates/post-list.vto
+++ b/_includes/templates/post-list.vto
@@ -6,12 +6,11 @@
           href="{{ post.url }}"
           {{ if post.url == url }}
             aria-current="page"{{ /if }}
-        >
-          {{
-            post.title || post.url.substr(1, post.url.length - 2)
-            |> replaceAll(/-(?!\d)/g, ` `)
-          }}
-        </a>
+        >{{-
+          post.title || post.basename
+          |> replaceAll(/-(?!\d)/g, ` `)
+          |> replace(/\b\w/, (char) => char.toUpperCase())
+        -}}</a>
       </h2>
 
       {{

--- a/_includes/templates/post-list.vto
+++ b/_includes/templates/post-list.vto
@@ -6,11 +6,7 @@
           href="{{ post.url }}"
           {{ if post.url == url }}
             aria-current="page"{{ /if }}
-        >{{-
-          post.title || post.basename
-          |> replaceAll(/-(?!\d)/g, ` `)
-          |> replace(/\b\w/, (char) => char.toUpperCase())
-        -}}</a>
+        >{{ post.title }}</a>
       </h2>
 
       {{

--- a/index.vto
+++ b/index.vto
@@ -20,13 +20,11 @@ title: Home
               href="{{ post.url }}"
               {{ if post.url == url }}
                 aria-current="page"{{ /if }}
-            >
-              {{
-                post.title ||
-                  post.url.substr(1, post.url.length - 2)
-                |> replaceAll(/-(?!\d)/g, ` `)
-              }}
-            </a>
+            >{{-
+              post.title || post.basename
+              |> replaceAll(/-(?!\d)/g, ` `)
+              |> replace(/\b\w/g, (char) => char.toUpperCase())
+            -}}</a>
           </h2>
 
           {{

--- a/index.vto
+++ b/index.vto
@@ -20,11 +20,7 @@ title: Home
               href="{{ post.url }}"
               {{ if post.url == url }}
                 aria-current="page"{{ /if }}
-            >{{-
-              post.title || post.basename
-              |> replaceAll(/-(?!\d)/g, ` `)
-              |> replace(/\b\w/g, (char) => char.toUpperCase())
-            -}}</a>
+            >{{ post.title }}</a>
           </h2>
 
           {{

--- a/plugins.ts
+++ b/plugins.ts
@@ -1,5 +1,6 @@
 import baseBlog from "https://deno.land/x/lume_theme_simple_blog@v1.16.2/mod.ts";
 import type { Options as BaseBlogOptions } from "https://deno.land/x/lume_theme_simple_blog@v1.16.2/mod.ts";
+import extractDate from "lume/plugins/extract_date.ts";
 import favicon from "lume/plugins/favicon.ts";
 import googleFonts from "lume/plugins/google_fonts.ts";
 import { merge } from "lume/core/utils/object.ts";
@@ -78,6 +79,7 @@ export default function (userOptions?: Options) {
     site.data("colorscheme", options.colors);
 
     site.use(baseBlog(options))
+      .use(extractDate())
       .use(favicon())
       .use(googleFonts({
         cssFile: "styles.css",

--- a/posts/2025-12-solstice.md
+++ b/posts/2025-12-solstice.md
@@ -1,0 +1,32 @@
+---
+date: "2025-12-21T15:03Z"
+author: Ricky de Laveaga
+---
+
+A post with the title but no date in the filename, `2025-12-solstice.md`, with
+`date` (as `2025-12-21T15:03Z`, the
+[2025 December Solstice](https://earthsky.org/astronomy-essentials/everything-you-need-to-know-december-solstice/))
+and author but no `title` in frontmatter.
+
+<!--more-->
+
+## Frontmatter optional
+
+This makes sure our title parsing and usage of
+[Lume’s Extract date plugin](https://lume.land/plugins/extract_date/) behaves in
+this scenario with a title in the filename but no date.
+
+> You have to prepend the date to the filename using the `yyyy-mm-dd` syntax
+> followed by a hyphen `-` or an underscore `_` (or `yyyy-mm-dd-hh-ii-ss` if you
+> also need the time). Note that [the date] is removed [by default] when
+> generating the final url […] Dates can be defined in folders, so it's shared
+> by all pages inside […]
+
+– [Extract date, lume.land](https://lume.land/plugins/extract_date/#description)
+
+The date at the beginning should not be parsed and is assumed here to be part of
+the title since it is incomplete. With the current implementation,
+`solstice-2025-12.md` would end up keeping the hyphen and render as
+“Solstice-2025-12” with “Solstice 2025-12” here. I consider this inconsistency a
+limitation I can live with for now. There is a draft in the example posts that
+tests the scenario with a date and title in the filename.

--- a/posts/2161-01-06.md
+++ b/posts/2161-01-06.md
@@ -1,8 +1,0 @@
----
-date: '2161-01-16T16:00:00Z'
-draft: true
----
-
-a titleless draft post in a file named 2161-01-16.md
-
-Feeling great about the founding of [The United Federation of Planets](https://en.wikipedia.org/wiki/United_Federation_of_Planets) by Earth, Tellar, Andoria, and Vulcan 🖖

--- a/posts/2161-01-16-13-00-00-stardate-foundation.md
+++ b/posts/2161-01-16-13-00-00-stardate-foundation.md
@@ -1,0 +1,38 @@
+---
+author: Ricky de Laveaga
+draft: true
+---
+
+A draft post with the title and date in the filename,
+`2161-01-16-13-00-00-stardate-foundation.md`, without a `date` or `title` in the
+frontmatter, but with `draft` set to true and the `author`.
+
+<!--more-->
+
+## Frontmatter optional
+
+This tests our title parsing and usage of
+[Lume’s Extract date plugin](https://lume.land/plugins/extract_date/) in this
+scenario with a date and title in the filename.
+
+> You have to prepend the date to the filename using the `yyyy-mm-dd` syntax
+> followed by a hyphen `-` or an underscore `_` (or `yyyy-mm-dd-hh-ii-ss` if you
+> also need the time). Note that [the date] is removed [by default] when
+> generating the final url […] Dates can be defined in folders, so it's shared
+> by all pages inside […]
+
+– [Extract date, lume.land](https://lume.land/plugins/extract_date/#description)
+
+`2161-01-16_stardate-foundation.md` would also work nearly the same except the
+time would default to 00:00 UTC instead of 13:00. The trailing hyphen or
+underscore is required by `extract_date`. Providing the time is optional, here
+13:00, as `-13-00-00` at the end, gets around most
+[time offsets from UTC](https://en.wikipedia.org/wiki/List_of_UTC_offsets) that
+cause the date to shift in certain time zones, most often in New Zealand,
+Kiribati, Samoa, Tonga, and USA Minor Outlying Islands.
+
+## [Stardate](https://en.wikipedia.org/wiki/Stardate) 2161
+
+Feeling great about the founding of
+[The United Federation of Planets](https://en.wikipedia.org/wiki/United_Federation_of_Planets)
+by Earth, Tellar, Andoria, and Vulcan 🖖

--- a/posts/_data.yml
+++ b/posts/_data.yml
@@ -1,6 +1,3 @@
 type: post
 layout: layouts/post.vto
 basename: /
-
-metas:
-  title: =title

--- a/posts/differences.md
+++ b/posts/differences.md
@@ -1,6 +1,6 @@
 ---
 title: Differences between Xeo and Simple Blog
-date: "2025-01-19T16:00:00.000Z"
+date: "2025-01-19T13:00Z"
 author: Ricky de Laveaga
 tags:
   - Design

--- a/posts/elegance.md
+++ b/posts/elegance.md
@@ -1,6 +1,6 @@
 ---
 title: Elegance
-date: "2025-04-18T16:00:00.000Z"
+date: "2025-04-18T13:00Z"
 author: Dan Forsyth
 tags:
   - Design

--- a/posts/instructions.md
+++ b/posts/instructions.md
@@ -1,6 +1,6 @@
 ---
 title: How to install Xeo
-date: "2025-01-13T16:00:00.000Z"
+date: "2025-01-13T13:00Z"
 author: Ricky de Laveaga
 tags:
   - Instructions

--- a/posts/no-title/index.md
+++ b/posts/no-title/index.md
@@ -1,5 +1,7 @@
 ---
-date: '2025-01-01T16:00:00Z'
+date: "2025-01-01T13:00Z"
+author: Ricky de Laveaga
 ---
 
-a titleless post in file named `index.md` in a folder named `no-title`
+A post with `date` and `author` in the frontmatter but no title, in a file named
+`index.md` inside a folder named `no-title`.


### PR DESCRIPTION
- Build on work in 7abc7da handle titleless posts #32

  + use `basename` in place of `url`, reducing cleanup, thanks @oscarotero

  + handle filename titles better and convert them to sentence case

  + parse dates with Extract date plugin

- Add another test post with a title but no/an incomplete date