### PR TITLE
Include post-list.vto in mod.ts

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -21,6 +21,7 @@ export default function (options: Partial<Options> = {}) {
       "_includes/layouts/page.vto",
       "_includes/layouts/post.vto",
       "_includes/templates/post-details.vto",
+      "_includes/templates/post-list.vto",
       "pages/color-options.vto",
       "posts/_data.yml",
       "_data.yml",


### PR DESCRIPTION
Added `post-list.vto` to Xeo in #32 and refined usage in #33 but it needs to be in `mod.ts` so theme users get it