### PR TITLE
v7 stand-alone complex - child no more

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-2025 Óscar Otero and Ricky de Laveaga
+Copyright (c) 2022-2026 Óscar Otero and Ricky de Laveaga
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-2026 Óscar Otero and Ricky de Laveaga
+Copyright (c) 2022-present Óscar Otero and Ricky de Laveaga
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ will create a new project with Xeo configured.
 
 - `deno task serve` to start a local server
 
-- [`deno task d`](./deno.json) also runs `deno task lume -s`, if you are into
-  the whole
+- [`deno task d`](./deno.json) also runs `serve`, if you are into the whole
   [brevity thing](https://en.wikiquote.org/wiki/The_Big_Lebowski#Jeffrey_%22The_Dude%22_Lebowski).
 
 - `deno task lup` upgrades Lume via `deno task lume upgrade`

--- a/README.md
+++ b/README.md
@@ -19,13 +19,15 @@ welcome: [famebot/xeo on GitHub](https://github.com/famebot/xeo))
 > subscribers, and share the same design foundation. Over time, eventually Xeo
 > diverged substantially enough from Simple Blog that Óscar and Ricky agreed it
 > was time for Xeo to become a fully stand-alone
-> [Lume theme](https://lume.land/theme/xeo/). As of Xeo version 7.0, the
-> successor to v6.3.8, Xeo no longer depends on Simple Blog as its parent theme.
-> Because Xeo is no longer a child theme, using Xeo as a parent theme to make
-> your own child theme just got easier. Another bonus of the split is that
-> Simple Blog can now freely implement features that landed in Xeo first (like
-> custom fonts and colors) without having to worry about compatibility issues
-> with Xeo or downstream themes and sites that depend on Xeo.
+> [Lume theme](https://lume.land/theme/xeo/).
+>
+> As of Xeo version 7.0, the successor to v6.3.8, Xeo no longer depends on
+> Simple Blog as its parent theme. Because Xeo is no longer a child theme, using
+> Xeo as a parent theme to make your own child theme just got easier. Another
+> bonus of the split is that Simple Blog can now freely implement features that
+> landed in Xeo first (like custom fonts and colors) without having to worry
+> about compatibility issues with Xeo or downstream themes and sites that depend
+> on Xeo.
 
 ## Quick start 🎬
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,31 @@
 # [🔥&nbsp;Lume](https://translate.google.com/?sl=gl&tl=en&text=Lume&op=translate) + [Xeo&nbsp;🧊](https://translate.google.com/?sl=gl&tl=en&text=Xeo&op=translate)
 
-Welcome to **Xeo**, a _deluxe_ variant of
-[**Lume Simple Blog**](https://lume.land/theme/simple-blog/).
+Welcome to **Xeo**, a _deluxe_
+[**Lume theme**](https://lume.land/theme/simple-blog/).
 
 Visit [xeo.land](https://xeo.land) for the live demo.
 
 [**Release Notes**](https://github.com/famebot/xeo/releases) (Contributions
 welcome: [famebot/xeo on GitHub](https://github.com/famebot/xeo))
 
-&copy; 2022-2025 [Óscar Otero](https://oscarotero.com/) &amp;
+&copy; 2022-present [Óscar Otero](https://oscarotero.com/) &amp;
 [Ricky de Laveaga](https://rdela.com/); [MIT License](./LICENSE.md)
+
+> [!NOTE]
+> **Xeo** began as Ricky de Laveaga’s _deluxe_ variant of
+> [**Simple Blog**](https://lume.land/theme/simple-blog/) by Óscar Otero, a
+> clean and minimal blog theme for [**Lume**](https://lume.land/) with support
+> for tags and authors. Simple Blog and Xeo both provide Atom and JSON feeds for
+> subscribers, and share the same design foundation. Over time, eventually Xeo
+> diverged substantially enough from Simple Blog that Óscar and Ricky agreed it
+> was time for Xeo to become a fully stand-alone
+> [Lume theme](https://lume.land/theme/xeo/). As of Xeo version 7.0, the
+> successor to v6.3.8, Xeo no longer depends on Simple Blog as its parent theme.
+> Because Xeo is no longer a child theme, using Xeo as a parent theme to make
+> your own child theme just got easier. Another bonus of the split is that
+> Simple Blog can now freely implement features that landed in Xeo first (like
+> custom fonts and colors) without having to worry about compatibility issues
+> with Xeo or downstream themes and sites that depend on Xeo.
 
 ## Quick start 🎬
 

--- a/_config.ts
+++ b/_config.ts
@@ -1,14 +1,8 @@
 import lume from "lume/mod.ts";
-import blog from "./mod.ts";
+import plugins from "./plugins.ts";
 
 const site = lume();
 
-/*
-1. Use Simple Blog theme as parent theme.
-2. Create preprocessor to ensure all pages have a title, so we do not need to generate
-   it in the templates.
-*/
-site
-  .use(blog());
+site.use(plugins());
 
 export default site;

--- a/_data.yml
+++ b/_data.yml
@@ -1,7 +1,7 @@
 lang: en
 home:
   welcome: "\U0001F525 <a href=\"https://translate.google.com/?sl=gl&tl=en&text=Lume%20e%20Xeo&op=translate\">Lume e Xeo</a> \U0001F9CA"
-  intro: "Welcome to [**Xeo**](https://github.com/famebot/xeo), a *deluxe* variant of [**Lume&nbsp;Simple&nbsp;Blog**](https://lume.land/theme/simple-blog/)"
+  intro: "Welcome to [**Xeo**](https://github.com/famebot/xeo), a *deluxe* [**Lume&nbsp;theme**](https://lume.land/theme/xeo/)."
 
 copyright: "[Xeo](https://github.com/famebot/xeo) &copy; 2022-present [Óscar&nbsp;Otero](https://oscarotero.com/) &amp; [Ricky&nbsp;de&nbsp;Laveaga](https://rdela.com/)"
 
@@ -12,7 +12,7 @@ logo_height: 48
 
 metas:
   site: Xeo (demo)
-  description: Lume Simple Blog variant
+  description: A deluxe Lume theme
   title: "=title"
   image: "=image"
   # twitter: "@famebot"

--- a/_includes/css/navbar.css
+++ b/_includes/css/navbar.css
@@ -1,0 +1,35 @@
+.navbar {
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: 1rem;
+  row-gap: 1rem;
+  justify-content: space-between;
+  padding: 2rem min(5vw, 5rem);
+  align-items: center;
+}
+
+.navbar-links {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: 1.5rem;
+  font: var(--font-ui-bold);
+  align-items: center;
+
+  & [aria-current="page"] {
+    text-decoration: none;
+  }
+}
+
+.navbar-search {
+  padding: 0 1em;
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+}
+
+.navbar-home {
+  text-decoration: none;
+}

--- a/_includes/templates/pagination.vto
+++ b/_includes/templates/pagination.vto
@@ -1,0 +1,23 @@
+{{ if pagination.totalPages !== 1 }}
+  <nav class="page-pagination pagination">
+    <ul>
+      {{- if pagination.previous }}
+        <li class="pagination-prev">
+          <a href="{{ pagination.previous }}" rel="prev">{{
+            i18n.nav.previous
+          }}</a>
+        </li>
+      {{ /if }}
+
+      <li class="pagination-page">
+        {{ i18n.nav.page }} {{ pagination.page }}
+      </li>
+
+      {{- if pagination.next }}
+        <li class="pagination-next">
+          <a href="{{ pagination.next }}" rel="next">{{ i18n.nav.next }}</a>
+        </li>
+      {{ /if }}
+    </ul>
+  </nav>
+{{ /if }}

--- a/archive_result.page.js
+++ b/archive_result.page.js
@@ -1,0 +1,34 @@
+export const layout = "layouts/archive_result.vto";
+
+export default function* ({ search, i18n, paginate }) {
+  // Generate a page for each tag
+  for (const tag of search.values("tags")) {
+    const url = (n) => (n === 1) ? `/archive/${tag}/` : `/archive/${tag}/${n}/`;
+    const pages = search.pages(`type=post '${tag}'`);
+
+    for (const page of paginate(pages, { url, size: 10 })) {
+      yield {
+        ...page,
+        title: `${i18n.search.by_tag}  “${tag}”`,
+        type: "tag",
+        tag,
+      };
+    }
+  }
+
+  // Generate a page for each author
+  for (const author of search.values("author")) {
+    const url = (n) =>
+      (n === 1) ? `/author/${author}/` : `/archive/${author}/${n}/`;
+    const pages = search.pages(`type=post author='${author}'`);
+
+    for (const page of paginate(pages, { url, size: 10 })) {
+      yield {
+        ...page,
+        title: `${i18n.search.by_author} ${author}`,
+        type: "author",
+        author,
+      };
+    }
+  }
+}

--- a/deno.json
+++ b/deno.json
@@ -70,14 +70,15 @@
       "import": [
         "cdn.jsdelivr.net:443",
         "jsr.io:443",
-        "deno.land:443",
-        "esm.sh:443"
+        "deno.land:443"
       ],
       "net": [
         "0.0.0.0",
-        "jsr.io:443",
         "cdn.jsdelivr.net:443",
         "data.jsdelivr.com:443",
+        "fonts.googleapis.com:443",
+        "fonts.gstatic.com:443",
+        "jsr.io:443",
         "registry.npmjs.org:443"
       ],
       "env": true,

--- a/deno.json
+++ b/deno.json
@@ -1,14 +1,14 @@
 {
   "imports": {
-    "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/",
+    "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.3/",
     "blog/": "https://deno.land/x/lume_theme_simple_blog@v1.16.2/",
-    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.14.2/",
-    "lume/jsx-runtime": "https://cdn.jsdelivr.net/gh/oscarotero/ssx@0.1.12/jsx-runtime.ts"
+    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.14.4/",
+    "lume/jsx-runtime": "https://cdn.jsdelivr.net/gh/oscarotero/ssx@0.1.14/jsx-runtime.ts"
   },
   "tasks": {
     "lume": {
       "description": "Run Lume command",
-      "command": "deno run -A lume/cli.ts"
+      "command": "deno run -P=lume lume/cli.ts"
     },
     "prod": "deno task lume --location=https://xeo.land",
     "build": {
@@ -26,7 +26,7 @@
     },
     "up": {
       "description": "Upgrade dependencies, including Lume",
-      "command": "deno run -A --quiet 'https://deno.land/x/nudd@v0.2.10/cli.ts' update plugins.ts deno.json"
+      "command": "deno run -A --quiet 'https://deno.land/x/nudd@v0.2.11/cli.ts' update plugins.ts deno.json"
     }
   },
   "compilerOptions": {
@@ -49,7 +49,7 @@
       ]
     },
     "plugins": [
-      "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/lint.ts"
+      "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.3/lint.ts"
     ]
   },
   "fmt": {

--- a/mod.ts
+++ b/mod.ts
@@ -12,6 +12,7 @@ export default function (options: Partial<Options> = {}) {
     // Add remote files
     const files: string[] = [
       "_includes/css/ds.css",
+      "_includes/css/navbar.css",
       "_includes/css/page.css",
       "_includes/css/post-list.css",
       "_includes/css/post.css",
@@ -20,6 +21,7 @@ export default function (options: Partial<Options> = {}) {
       "_includes/layouts/base.vto",
       "_includes/layouts/page.vto",
       "_includes/layouts/post.vto",
+      "_includes/templates/pagination.vto",
       "_includes/templates/post-details.vto",
       "_includes/templates/post-list.vto",
       "pages/color-options.vto",
@@ -27,6 +29,7 @@ export default function (options: Partial<Options> = {}) {
       "_data.yml",
       "_data/i18n.yml",
       "404.md",
+      "archive_result.page.js",
       "archive.page.js",
       "favicon.svg",
       "index.vto",

--- a/plugins.ts
+++ b/plugins.ts
@@ -1,17 +1,34 @@
-import baseBlog from "https://deno.land/x/lume_theme_simple_blog@v1.16.2/mod.ts";
-import type { Options as BaseBlogOptions } from "https://deno.land/x/lume_theme_simple_blog@v1.16.2/mod.ts";
+// lume/core
+import { merge } from "lume/core/utils/object.ts";
+// lume/plugins
+import basePath from "lume/plugins/base_path.ts";
+import date, { Options as DateOptions } from "lume/plugins/date.ts";
 import extractDate from "lume/plugins/extract_date.ts";
 import favicon from "lume/plugins/favicon.ts";
+import feed, { Options as FeedOptions } from "lume/plugins/feed.ts";
 import googleFonts from "lume/plugins/google_fonts.ts";
-import { merge } from "lume/core/utils/object.ts";
+import metas from "lume/plugins/metas.ts";
+import pagefind, { Options as PagefindOptions } from "lume/plugins/pagefind.ts";
+import postcss from "lume/plugins/postcss.ts";
+import prism, { Options as PrismOptions } from "lume/plugins/prism.ts";
+import readingInfo from "lume/plugins/reading_info.ts";
+import resolveUrls from "lume/plugins/resolve_urls.ts";
+import sitemap from "lume/plugins/sitemap.ts";
+import slugifyUrls from "lume/plugins/slugify_urls.ts";
+/* Simple Blog uses Terser for comments JS we skip here, but may want for
+   rainbow mode JS when that lands, .use() commented out below as well */
+// import terser from "lume/plugins/terser.ts";
+// lumeland/markdown-plugins
+import footnotes from "https://cdn.jsdelivr.net/gh/lumeland/markdown-plugins@0.10.0/footnotes.ts";
+import image from "https://cdn.jsdelivr.net/gh/lumeland/markdown-plugins@0.10.0/image.ts";
+import toc from "https://cdn.jsdelivr.net/gh/lumeland/markdown-plugins@0.10.0/toc.ts";
+// https://github.com/mdit-plugins/mdit-plugins
+// docs https://mdit-plugins.github.io/alert.html
+import { alert } from "https://cdn.jsdelivr.net/npm/@mdit/plugin-alert@0.22.3/lib/index.js";
 
 import "lume/types.ts";
 
-export interface Options extends BaseBlogOptions {
-  fonts?: {
-    display?: string;
-    text?: string;
-  };
+export interface Options {
   colors?: {
     hue?: number;
     complement?: number;
@@ -27,32 +44,31 @@ export interface Options extends BaseBlogOptions {
     darkness?: number;
     darker?: number;
   };
+
+  date?: Partial<DateOptions>;
+  feed?: Partial<FeedOptions>;
+
+  fonts?: {
+    display?: string;
+    text?: string;
+  };
+
+  pagefind?: Partial<PagefindOptions>;
+  prism?: Partial<PrismOptions>;
 }
 
 export const defaults: Options = {
-  feed: {
-    output: ["/feed.xml", "/feed.json"],
-    query: "type=post",
-    info: {
-      title: "=metas.site",
-      description: "=metas.description",
-    },
-    items: {
-      title: "=title",
-    },
-  },
-  fonts: {
-    display: "https://fonts.google.com/share?selection.family=Bebas+Neue",
-    text:
-      "https://fonts.google.com/share?selection.family=Lexend:wght@100..900",
-  },
   colors: {
-    // HSL hues
-    // In CSS, an `<angle>` is periodic, `<hue>` is normalized to the range
-    // [0deg, 360deg). It implicitly wraps around such that 480deg is the same
-    // as 120deg, -120deg is the same as 240deg, -1turn is the same as 1turn,
-    // and so on. Yet, here we pass an integer 1-359 for each of the
-    // 3 hue values, to get type checking.
+    /*
+      HSL hues
+      In CSS, an `<angle>` is periodic, `<hue>` is normalized to the range
+      [0deg, 360deg). It implicitly wraps around such that 480deg is the same
+      as 120deg, -120deg is the same as 240deg, -1turn is the same as 1turn,
+      and so on. Yet here we pass a number
+      https://www.typescriptlang.org/docs/handbook/2/everyday-types.html
+      1-359 for each of the 3 hue values, to get simple type inference
+      https://www.typescriptlang.org/docs/handbook/type-inference.html
+    */
     hue: 172,
     complement: 351,
     analogous: 38,
@@ -69,6 +85,24 @@ export const defaults: Options = {
     darkness: 20, // 16-24
     darker: 9, // 0-12
   },
+
+  feed: {
+    output: ["/feed.xml", "/feed.json"],
+    query: "type=post",
+    info: {
+      title: "=metas.site",
+      description: "=metas.description",
+    },
+    items: {
+      title: "=title",
+    },
+  },
+
+  fonts: {
+    display: "https://fonts.google.com/share?selection.family=Bebas+Neue",
+    text:
+      "https://fonts.google.com/share?selection.family=Lexend:wght@100..900",
+  },
 };
 
 /** Configure the site */
@@ -78,17 +112,36 @@ export default function (userOptions?: Options) {
   return (site: Lume.Site) => {
     site.data("colorscheme", options.colors);
 
-    site
-      .ignore("README.md")
-      .ignore("LICENSE.md")
-      .use(baseBlog(options))
+    // .use(terser())
+    site.use(googleFonts({
+      cssFile: "styles.css",
+      placeholder: "/* google-fonts */",
+      fonts: options.fonts,
+    }))
+      .use(postcss())
+      .use(basePath())
+      .use(toc())
+      .use(prism(options.prism))
+      .use(readingInfo())
+      .use(date(options.date))
+      .use(slugifyUrls())
+      .use(metas())
+      .use(image())
+      .use(footnotes())
+      .use(resolveUrls())
+      .use(pagefind(options.pagefind))
+      .use(sitemap())
+      .use(feed(options.feed))
       .use(extractDate())
       .use(favicon())
-      .use(googleFonts({
-        cssFile: "styles.css",
-        placeholder: "/* google-fonts */",
-        fonts: options.fonts,
-      }))
+      .ignore("README.md")
+      .ignore("LICENSE.md")
+      .add("fonts")
+      .add([".css"])
+      .add("js")
+      .add("favicon.png")
+      .add("uploads")
+      .mergeKey("extra_head", "stringArray")
       .preprocess([".md"], (pages) => {
         for (const page of pages) {
           if (!page.data.title) {
@@ -96,7 +149,14 @@ export default function (userOptions?: Options) {
               .replaceAll(/-(?!\d)/g, ` `) // remove hyphens unless followed by 0-9
               .replace(/\b\w/, (char) => char.toUpperCase()); // sentence case
           } // for title case use /\b\w/g
+
+          page.data.excerpt ??= (page.data.content as string).split(
+            /<!--\s*more\s*-->/i,
+          )[0];
         }
       });
+
+    // Alert plugin
+    site.hooks.addMarkdownItPlugin(alert);
   };
 }

--- a/posts/2025-12-solstice.md
+++ b/posts/2025-12-solstice.md
@@ -25,7 +25,7 @@ and author are in frontmatter, but there is no need to put a `title`, thanks to
 Since the current implementation uses a
 [negative lookahead](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookahead_assertion)
 to
-[remove hyphens that do not precede digigits 0-9](https://github.com/famebot/xeo/blob/trunk/plugins.ts#L144),
+[remove hyphens that do not precede digits 0-9](https://github.com/famebot/xeo/blob/trunk/plugins.ts#L144),
 `solstice-2025-12.md` would end up keeping the hyphen and render as
 “Solstice-2025-12” compared to “2025-12 solstice” here. I consider this
 inconsistency a limitation I can live with for now. There is a draft in the

--- a/posts/2025-12-solstice.md
+++ b/posts/2025-12-solstice.md
@@ -7,12 +7,14 @@ This post only has the title in the filename, `2025-12-solstice.md`. Because the
 partial date is incomplete and does not have a day value, it gets parsed as part
 of the title. The `date` (as `2025-12-21T15:03Z`, the
 [2025 December Solstice](https://earthsky.org/astronomy-essentials/everything-you-need-to-know-december-solstice/))
-and author are in frontmatter, but there is no need to put a `title`, thanks to
+and author are in
+[front matter](https://lume.land/docs/getting-started/page-data/), but there is
+no need to put a `title`, thanks to
 [Lume’s Extract date plugin](https://lume.land/plugins/extract_date/).
 
 <!--more-->
 
-## Frontmatter optional
+## Front matter optional
 
 > You have to prepend the date to the filename using the `yyyy-mm-dd` syntax
 > followed by a hyphen `-` or an underscore `_` (or `yyyy-mm-dd-hh-ii-ss` if you

--- a/posts/2025-12-solstice.md
+++ b/posts/2025-12-solstice.md
@@ -24,13 +24,13 @@ and author are in frontmatter, but there is no need to put a `title`, thanks to
 
 Since the current implementation uses a
 [negative lookahead](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookahead_assertion)
-to
-[remove hyphens that do not precede digits 0-9](https://github.com/famebot/xeo/blob/trunk/plugins.ts#L144),
+to remove hyphens that do not
+[precede digits 0-9](https://github.com/famebot/xeo/blob/trunk/plugins.ts#L144),
 `solstice-2025-12.md` would end up keeping the hyphen and render as
 “Solstice-2025-12” compared to “2025-12 solstice” here. I consider this
 inconsistency a limitation I can live with for now. There is a draft in the
 example posts that tests the scenario with a date and title in the filename.
 
 With [No title](/no-title/), the title in the built site comes from the
-[`basename`](https://lume.land/docs/creating-pages/urls/#basename) of the folder
-name (`no-title`) containing the file, `index.md`.
+[`basename`](https://lume.land/docs/creating-pages/urls/#basename) of the
+`no-title` folder containing the `index.md` file.

--- a/posts/2025-12-solstice.md
+++ b/posts/2025-12-solstice.md
@@ -3,18 +3,16 @@ date: "2025-12-21T15:03Z"
 author: Ricky de Laveaga
 ---
 
-A post with the title but no date in the filename, `2025-12-solstice.md`, with
-`date` (as `2025-12-21T15:03Z`, the
+This post only has the title in the filename, `2025-12-solstice.md`. Because the
+partial date is incomplete and does not have a day value, it gets parsed as part
+of the title. The `date` (as `2025-12-21T15:03Z`, the
 [2025 December Solstice](https://earthsky.org/astronomy-essentials/everything-you-need-to-know-december-solstice/))
-and author but no `title` in frontmatter.
+and author are in frontmatter, but there is no need to put a `title`, thanks to
+[Lume’s Extract date plugin](https://lume.land/plugins/extract_date/).
 
 <!--more-->
 
 ## Frontmatter optional
-
-This makes sure our title parsing and usage of
-[Lume’s Extract date plugin](https://lume.land/plugins/extract_date/) behaves in
-this scenario with a title in the filename but no date.
 
 > You have to prepend the date to the filename using the `yyyy-mm-dd` syntax
 > followed by a hyphen `-` or an underscore `_` (or `yyyy-mm-dd-hh-ii-ss` if you
@@ -24,9 +22,15 @@ this scenario with a title in the filename but no date.
 
 – [Extract date, lume.land](https://lume.land/plugins/extract_date/#description)
 
-The date at the beginning should not be parsed and is assumed here to be part of
-the title since it is incomplete. With the current implementation,
+Since the current implementation uses a
+[negative lookahead](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookahead_assertion)
+to
+[remove hyphens that do not precede digigits 0-9](https://github.com/famebot/xeo/blob/trunk/plugins.ts#L144),
 `solstice-2025-12.md` would end up keeping the hyphen and render as
 “Solstice-2025-12” compared to “2025-12 solstice” here. I consider this
 inconsistency a limitation I can live with for now. There is a draft in the
 example posts that tests the scenario with a date and title in the filename.
+
+With [No title](/no-title/), the title in the built site comes from the
+[`basename`](https://lume.land/docs/creating-pages/urls/#basename) of the folder
+name (`no-title`) containing the file, `index.md`.

--- a/posts/2161-01-16-13-00-00-stardate-foundation.md
+++ b/posts/2161-01-16-13-00-00-stardate-foundation.md
@@ -29,12 +29,14 @@ underscore is required by Extract date. Providing the time is optional, here
 13:00, as `-13-00-00` at the end, gets around most
 [time offsets from UTC](https://en.wikipedia.org/wiki/List_of_UTC_offsets) that
 cause the date to shift in certain time zones, most often in New Zealand,
-Kiribati, Samoa, Tonga, and USA Minor Outlying Islands. Because the partial date
-in the [2025-12 solstice](/2025-12-solstice/) filename (`2025-12-solstice.md`)
-is incomplete and does not have a day value, it gets parsed as part of the
-title. With [No title](/no-title/), the title in the built site comes from the
-[`basename`](https://lume.land/docs/creating-pages/urls/#basename) of the folder
-name (`no-title`) containing the file, `index.md`.
+Kiribati, Samoa, Tonga, and USA Minor Outlying Islands. Because the partial,
+incomplete date in (`2025-12-solstice.md`) does not have a day value, it gets
+parsed as part of the title, [2025-12 solstice](/2025-12-solstice/).
+
+When Lume processes the `index.md` file contained in the `no-title` folder, the
+[`basename`](https://lume.land/docs/creating-pages/urls/#basename) gets
+transformed to “[No title](/no-title/)” in the built site because the `index.md`
+file works like an `index.html` file and assumes the name of its directory.
 
 ## [Stardate](https://en.wikipedia.org/wiki/Stardate) 2161
 

--- a/posts/2161-01-16-13-00-00-stardate-foundation.md
+++ b/posts/2161-01-16-13-00-00-stardate-foundation.md
@@ -25,11 +25,16 @@ scenario with a date and title in the filename.
 
 `2161-01-16_stardate-foundation.md` would also work nearly the same except the
 time would default to 00:00 UTC instead of 13:00. The trailing hyphen or
-underscore is required by `extract_date`. Providing the time is optional, here
+underscore is required by Extract date. Providing the time is optional, here
 13:00, as `-13-00-00` at the end, gets around most
 [time offsets from UTC](https://en.wikipedia.org/wiki/List_of_UTC_offsets) that
 cause the date to shift in certain time zones, most often in New Zealand,
-Kiribati, Samoa, Tonga, and USA Minor Outlying Islands.
+Kiribati, Samoa, Tonga, and USA Minor Outlying Islands. Because the partial date
+in the [2025-12 solstice](/2025-12-solstice/) filename (`2025-12-solstice.md`)
+is incomplete and does not have a day value, it gets parsed as part of the
+title. With [No title](/no-title/), the title in the built site comes from the
+[`basename`](https://lume.land/docs/creating-pages/urls/#basename) of the folder
+name (`no-title`) containing the file, `index.md`.
 
 ## [Stardate](https://en.wikipedia.org/wiki/Stardate) 2161
 

--- a/posts/2161-01-16-13-00-00-stardate-foundation.md
+++ b/posts/2161-01-16-13-00-00-stardate-foundation.md
@@ -3,17 +3,15 @@ author: Ricky de Laveaga
 draft: true
 ---
 
-A draft post with the title and date in the filename,
-`2161-01-16-13-00-00-stardate-foundation.md`, without a `date` or `title` in the
-frontmatter, but with `draft` set to true and the `author`.
+A post where all we have is `draft` set to true and the `author` in the
+[front matter](https://lume.land/docs/getting-started/page-data/). The `date`
+and `title` get set by
+[Lume’s Extract date plugin](https://lume.land/plugins/extract_date/) from the
+filename, (`2161-01-16-13-00-00-stardate-foundation.md`).
 
 <!--more-->
 
-## Frontmatter optional
-
-This tests our title parsing and usage of
-[Lume’s Extract date plugin](https://lume.land/plugins/extract_date/) in this
-scenario with a date and title in the filename.
+## Front matter optional
 
 > You have to prepend the date to the filename using the `yyyy-mm-dd` syntax
 > followed by a hyphen `-` or an underscore `_` (or `yyyy-mm-dd-hh-ii-ss` if you
@@ -31,15 +29,15 @@ underscore is required by Extract date. Providing the time is optional, here
 cause the date to shift in certain time zones, most often in New Zealand,
 Kiribati, Samoa, Tonga, and USA Minor Outlying Islands. Because the partial,
 incomplete date in (`2025-12-solstice.md`) does not have a day value, it gets
-parsed as part of the title, [2025-12 solstice](/2025-12-solstice/).
+parsed as part of the title, [2025-12&nbsp;solstice](/2025-12-solstice/).
 
 When Lume processes the `index.md` file contained in the `no-title` folder, the
 [`basename`](https://lume.land/docs/creating-pages/urls/#basename) gets
 transformed to “[No title](/no-title/)” in the built site because the `index.md`
-file works like an `index.html` file and assumes the name of its directory.
+file works like an `index.html` file and assumes the name of its&nbsp;directory.
 
 ## [Stardate](https://en.wikipedia.org/wiki/Stardate) 2161
 
 Feeling great about the founding of
 [The United Federation of Planets](https://en.wikipedia.org/wiki/United_Federation_of_Planets)
-by Earth, Tellar, Andoria, and Vulcan 🖖
+by Earth, Tellar, Andoria, and&nbsp;Vulcan&nbsp;🖖

--- a/posts/differences.md
+++ b/posts/differences.md
@@ -16,12 +16,22 @@ for&nbsp;you!
 
 To recap [How to install Xeo:](/instructions/)
 
-> [**Xeo**](https://github.com/famebot/xeo) is
-> [Ricky de Laveaga’s](https://rdela.com/) variant of
+> [**Xeo**](https://github.com/famebot/xeo) began as
+> [Ricky de Laveaga’s](https://rdela.com/) _deluxe_ variant of
 > [**Simple Blog**](https://lume.land/theme/simple-blog/) by
 > [Óscar Otero](https://oscarotero.com/), a clean and minimal blog theme for
 > [**Lume**](https://lume.land/) with support for tags and authors. Simple Blog
-> and Xeo both provide Atom and JSON feeds for&nbsp;subscribers.
+> and Xeo both provide Atom and JSON feeds for subscribers. Simple Blog and Xeo
+> both provide Atom and JSON feeds for subscribers, and share the same design
+> foundation. Over time, eventually Xeo diverged substantially enough from
+> Simple Blog that Óscar and Ricky agreed it was time for Xeo to become a fully
+> stand-alone [Lume theme](https://lume.land/theme/xeo/). As of Xeo version 7.0,
+> the successor to v6.3.8, Xeo no longer depends on Simple Blog as its parent
+> theme. Because Xeo is no longer a child theme, using Xeo as a parent theme to
+> make your own child theme just got easier. Another bonus of the split is that
+> Simple Blog can now freely implement features that landed in Xeo first (like
+> custom fonts and colors) without having to worry about compatibility issues
+> with Xeo or downstream themes and sites that depend on&nbsp;Xeo.
 
 Where do they diverge?
 
@@ -93,3 +103,32 @@ Where do they diverge?
   [eleventeen](https://eleventeen.blog/about/). Chromagen generated Xeo’s
   current color schemes, but has not yet been wired up to Xeo to the degree it
   has been integrated into&nbsp;eleventeen.
+
+## [Frontmatter optional](/2025-12-solstice/)
+
+Xeo uses [Lume’s Extract date plugin](https://lume.land/plugins/extract_date/)
+to parse dates and titles from filenames.
+
+> You have to prepend the date to the filename using the `yyyy-mm-dd` syntax
+> followed by a hyphen `-` or an underscore `_` (or `yyyy-mm-dd-hh-ii-ss` if you
+> also need the time). Note that [the date] is removed [by default] when
+> generating the final url […] Dates can be defined in folders, so it's shared
+> by all pages inside […]
+
+– [Extract date, lume.land](https://lume.land/plugins/extract_date/#description)
+
+The date must be at the beginning and complete. The trailing hyphen or
+underscore following the date and preceding the title is required by Extract
+date. Providing the time is optional. There is a draft in the example posts that
+tests the scenario with a date and title in the filename and supplies 13:00, as
+`-13-00-00` at the end. This gets around most
+[time offsets from UTC](https://en.wikipedia.org/wiki/List_of_UTC_offsets) that
+cause the date to shift in certain time zones, most often in New Zealand,
+Kiribati, Samoa, Tonga, and USA Minor Outlying Islands. The
+[No title](/no-title/) and [2025-12 solstice](/2025-12-solstice/) example posts
+both have `date` and `author` in the frontmatter. With [No title](/no-title/),
+the title in the built site comes from the
+[`basename`](https://lume.land/docs/creating-pages/urls/#basename) of the folder
+name (`no-title`) containing the file, `index.md`. Because the partial date in
+the [2025-12 solstice](/2025-12-solstice/) filename (`2025-12-solstice.md`) is
+incomplete and does not have a day value, it gets parsed as part of the title.

--- a/posts/differences.md
+++ b/posts/differences.md
@@ -105,7 +105,7 @@ Where do they diverge?
   current color schemes, but has not yet been wired up to Xeo to the degree it
   has been integrated into&nbsp;eleventeen.
 
-## [Frontmatter optional](/2025-12-solstice/)
+## [Front matter optional](/2025-12-solstice/)
 
 Xeo uses [Lume’s Extract date plugin](https://lume.land/plugins/extract_date/)
 to parse dates and titles from filenames.
@@ -125,11 +125,14 @@ tests the scenario with a date and title in the filename and supplies 13:00, as
 `-13-00-00` at the end. This gets around most
 [time offsets from UTC](https://en.wikipedia.org/wiki/List_of_UTC_offsets) that
 cause the date to shift in certain time zones, most often in New Zealand,
-Kiribati, Samoa, Tonga, and USA Minor Outlying Islands. The
-[No title](/no-title/) and [2025-12 solstice](/2025-12-solstice/) example posts
-both have `date` and `author` in the frontmatter. With [No title](/no-title/),
-the title in the built site comes from the
-[`basename`](https://lume.land/docs/creating-pages/urls/#basename) of the folder
-name (`no-title`) containing the file, `index.md`. Because the partial date in
-the [2025-12 solstice](/2025-12-solstice/) filename (`2025-12-solstice.md`) is
-incomplete and does not have a day value, it gets parsed as part of the title.
+Kiribati, Samoa, Tonga, and USA Minor Outlying&nbsp;Islands.
+
+The [No title](/no-title/) and [2025-12 solstice](/2025-12-solstice/) example
+posts both have `date` and `author` in the
+[front matter](https://lume.land/docs/getting-started/page-data/). With
+[No title](/no-title/), the title in the built site comes from the
+[`basename`](https://lume.land/docs/creating-pages/urls/#basename) of the
+`no-title` folder containing the `index.md` file. Because the partial,
+incomplete date in the `2025-12-solstice.md` source filename does not have a day
+value, it gets parsed as part of the title,
+[2025-12&nbsp;solstice](/2025-12-solstice/).

--- a/posts/differences.md
+++ b/posts/differences.md
@@ -1,6 +1,6 @@
 ---
 title: Differences between Xeo and Simple Blog
-date: "2025-01-19T13:00Z"
+date: "2025-12-31T13:00Z"
 author: Ricky de Laveaga
 tags:
   - Design
@@ -21,17 +21,18 @@ To recap [How to install Xeo:](/instructions/)
 > [**Simple Blog**](https://lume.land/theme/simple-blog/) by
 > [Óscar Otero](https://oscarotero.com/), a clean and minimal blog theme for
 > [**Lume**](https://lume.land/) with support for tags and authors. Simple Blog
-> and Xeo both provide Atom and JSON feeds for subscribers. Simple Blog and Xeo
-> both provide Atom and JSON feeds for subscribers, and share the same design
-> foundation. Over time, eventually Xeo diverged substantially enough from
-> Simple Blog that Óscar and Ricky agreed it was time for Xeo to become a fully
-> stand-alone [Lume theme](https://lume.land/theme/xeo/). As of Xeo version 7.0,
-> the successor to v6.3.8, Xeo no longer depends on Simple Blog as its parent
-> theme. Because Xeo is no longer a child theme, using Xeo as a parent theme to
-> make your own child theme just got easier. Another bonus of the split is that
-> Simple Blog can now freely implement features that landed in Xeo first (like
-> custom fonts and colors) without having to worry about compatibility issues
-> with Xeo or downstream themes and sites that depend on&nbsp;Xeo.
+> and Xeo both provide Atom and JSON feeds for subscribers, and share the same
+> design foundation. Over time, eventually Xeo diverged substantially enough
+> from Simple Blog that Óscar and Ricky agreed it was time for Xeo to become a
+> fully stand-alone [Lume theme](https://lume.land/theme/xeo/).
+>
+> As of Xeo version 7.0, the successor to v6.3.8, Xeo no longer depends on
+> Simple Blog as its parent theme. Because Xeo is no longer a child theme, using
+> Xeo as a parent theme to make your own child theme just got easier. Another
+> bonus of the split is that Simple Blog can now freely implement features that
+> landed in Xeo first (like custom fonts and colors) without having to worry
+> about compatibility issues with Xeo or downstream themes and sites that depend
+> on&nbsp;Xeo.
 
 Where do they diverge?
 

--- a/posts/instructions.md
+++ b/posts/instructions.md
@@ -9,12 +9,21 @@ tags:
 draft: false
 ---
 
-[**Xeo**](https://github.com/famebot/xeo) is
-[Ricky de Laveaga’s](https://rdela.com/) variant of
+[**Xeo**](https://github.com/famebot/xeo) began as
+[Ricky de Laveaga’s](https://rdela.com/) _deluxe_ variant of
 [**Simple Blog**](https://lume.land/theme/simple-blog/) by
 [Óscar Otero](https://oscarotero.com/), a clean and minimal blog theme for
 [**Lume**](https://lume.land/) with support for tags and authors. Simple Blog
-and Xeo both provide Atom and JSON feeds for&nbsp;subscribers.
+and Xeo both provide Atom and JSON feeds for subscribers, and share the same
+design foundation. Over time, eventually Xeo diverged substantially enough from
+Simple Blog that Óscar and Ricky agreed it was time for Xeo to become a fully
+stand-alone [Lume theme](https://lume.land/theme/xeo/). As of Xeo version 7.0,
+the successor to v6.3.8, Xeo no longer depends on Simple Blog as its parent
+theme. Because Xeo is no longer a child theme, using Xeo as a parent theme to
+make your own child theme just got easier. Another bonus of the split is that
+Simple Blog can now freely implement features that landed in Xeo first (like
+custom fonts and colors) without having to worry about compatibility issues with
+Xeo or downstream themes and sites that depend on&nbsp;Xeo.
 
 <!--more-->
 

--- a/posts/instructions.md
+++ b/posts/instructions.md
@@ -1,6 +1,6 @@
 ---
 title: How to install Xeo
-date: "2025-01-13T13:00Z"
+date: "2025-12-30T13:00Z"
 author: Ricky de Laveaga
 tags:
   - Instructions
@@ -9,21 +9,24 @@ tags:
 draft: false
 ---
 
-[**Xeo**](https://github.com/famebot/xeo) began as
-[Ricky de Laveaga’s](https://rdela.com/) _deluxe_ variant of
-[**Simple Blog**](https://lume.land/theme/simple-blog/) by
-[Óscar Otero](https://oscarotero.com/), a clean and minimal blog theme for
-[**Lume**](https://lume.land/) with support for tags and authors. Simple Blog
-and Xeo both provide Atom and JSON feeds for subscribers, and share the same
-design foundation. Over time, eventually Xeo diverged substantially enough from
-Simple Blog that Óscar and Ricky agreed it was time for Xeo to become a fully
-stand-alone [Lume theme](https://lume.land/theme/xeo/). As of Xeo version 7.0,
-the successor to v6.3.8, Xeo no longer depends on Simple Blog as its parent
-theme. Because Xeo is no longer a child theme, using Xeo as a parent theme to
-make your own child theme just got easier. Another bonus of the split is that
-Simple Blog can now freely implement features that landed in Xeo first (like
-custom fonts and colors) without having to worry about compatibility issues with
-Xeo or downstream themes and sites that depend on&nbsp;Xeo.
+> [!NOTE]
+> [**Xeo**](https://github.com/famebot/xeo) began as
+> [Ricky de Laveaga’s](https://rdela.com/) _deluxe_ variant of
+> [**Simple Blog**](https://lume.land/theme/simple-blog/) by
+> [Óscar Otero](https://oscarotero.com/), a clean and minimal blog theme for
+> [**Lume**](https://lume.land/) with support for tags and authors. Simple Blog
+> and Xeo both provide Atom and JSON feeds for subscribers, and share the same
+> design foundation. Over time, eventually Xeo diverged substantially enough
+> from Simple Blog that Óscar and Ricky agreed it was time for Xeo to become a
+> fully stand-alone [Lume&nbsp;theme](https://lume.land/theme/xeo/).
+>
+> As of Xeo version 7.0, the successor to v6.3.8, Xeo no longer depends on
+> Simple Blog as its parent theme. Because Xeo is no longer a child theme, using
+> Xeo as a parent theme to make your own child theme just got easier. Another
+> bonus of the split is that Simple Blog can now freely implement features that
+> landed in Xeo first (like custom fonts and colors) without having to worry
+> about compatibility issues with Xeo or downstream themes and sites that depend
+> on&nbsp;Xeo.
 
 <!--more-->
 

--- a/posts/instructions.md
+++ b/posts/instructions.md
@@ -9,6 +9,20 @@ tags:
 draft: false
 ---
 
+Once you
+[install Deno](https://docs.deno.com/runtime/getting_started/installation/), the
+**fastest and easiest** way to configure this theme is the
+[Lume init command](https://deno.land/x/lume_init), which you can also copy
+easily from the [Xeo theme page](https://lume.land/theme/xeo/). Running:
+
+```bash
+deno run -A https://lume.land/init.ts --theme=xeo
+```
+
+will create a new project with Xeo&nbsp;configured.
+
+<!--more-->
+
 > [!NOTE]
 > [**Xeo**](https://github.com/famebot/xeo) began as
 > [Ricky de Laveaga’s](https://rdela.com/) _deluxe_ variant of
@@ -27,20 +41,6 @@ draft: false
 > landed in Xeo first (like custom fonts and colors) without having to worry
 > about compatibility issues with Xeo or downstream themes and sites that depend
 > on&nbsp;Xeo.
-
-<!--more-->
-
-Once you
-[install Deno](https://docs.deno.com/runtime/getting_started/installation/), the
-**fastest and easiest** way to configure this theme is the
-[Lume init command](https://deno.land/x/lume_init), which you can also copy
-easily from the [Xeo theme page](https://lume.land/theme/xeo/). Running:
-
-```bash
-deno run -A https://lume.land/init.ts --theme=xeo
-```
-
-will create a new project with Xeo&nbsp;configured.
 
 ## Personalize Xeo
 

--- a/posts/no-title/index.md
+++ b/posts/no-title/index.md
@@ -4,4 +4,12 @@ author: Ricky de Laveaga
 ---
 
 A post with `date` and `author` in the frontmatter but no title, in a file named
-`index.md` inside a folder named `no-title`.
+`index.md` inside a folder named `no-title`. Here the title in the built site,
+“No title,” comes from the
+[`basename`](https://lume.land/docs/creating-pages/urls/#basename) of the folder
+name containing the file.
+
+There is a draft in the example posts that tests the scenario with a date and
+title in the filename. In the [2025-12 solstice](/2025-12-solstice/) filename
+(`2025-12-solstice.md`) because the partial date is incomplete and does not have
+a day value, it gets parsed as part of the title.

--- a/posts/no-title/index.md
+++ b/posts/no-title/index.md
@@ -3,8 +3,9 @@ date: "2025-01-01T13:00Z"
 author: Ricky de Laveaga
 ---
 
-A post with `date` and `author` in the frontmatter, but no title. The source
-file named `index.md` is inside a folder named `no-title`. The
+A post with `date` and `author` in the
+[front matter](https://lume.land/docs/getting-started/page-data/), but no title.
+The source file named `index.md` is inside a folder named `no-title`. The
 [`basename`](https://lume.land/docs/creating-pages/urls/#basename) gets
 transformed to “No title” in the built site because the `index.md` file works
 like an `index.html` file and assumes the name of its directory.

--- a/posts/no-title/index.md
+++ b/posts/no-title/index.md
@@ -3,13 +3,13 @@ date: "2025-01-01T13:00Z"
 author: Ricky de Laveaga
 ---
 
-A post with `date` and `author` in the frontmatter but no title, in a file named
-`index.md` inside a folder named `no-title`. Here the title in the built site,
-“No title,” comes from the
-[`basename`](https://lume.land/docs/creating-pages/urls/#basename) of the folder
-name containing the file.
+A post with `date` and `author` in the frontmatter, but no title. The source
+file named `index.md` is inside a folder named `no-title`. The
+[`basename`](https://lume.land/docs/creating-pages/urls/#basename) gets
+transformed to “No title” in the built site because the `index.md` file works
+like an `index.html` file and assumes the name of its directory.
 
 There is a draft in the example posts that tests the scenario with a date and
 title in the filename. In the [2025-12 solstice](/2025-12-solstice/) filename
-(`2025-12-solstice.md`) because the partial date is incomplete and does not have
-a day value, it gets parsed as part of the title.
+(`2025-12-solstice.md`) the partial, incomplete date gets parsed as part of the
+title because it lacks a day value.


### PR DESCRIPTION
- Xeo has diverged substantially enough from Simple Blog that Óscar and Ricky agree it is time for Xeo to become a fully stand-alone Lume theme.

- As of Xeo version 7.0, the successor to v6.3.8, Xeo no longer depends on Simple Blog as its parent theme. Because Xeo is no longer a child theme, using Xeo as a parent theme to make your own child theme just got easier. Another bonus of the split is that Simple Blog can now freely implement features that landed in Xeo first (like custom fonts and colors) without having to worry about compatibility issues with Xeo or downstream themes and sites that depend on Xeo.

https://lume.land/theme/xeo/