### PR TITLE
rm blog import, appease no-import-prefix

### DIFF
--- a/archive_result.page.js
+++ b/archive_result.page.js
@@ -4,7 +4,7 @@ export default function* ({ search, i18n, paginate }) {
   // Generate a page for each tag
   for (const tag of search.values("tags")) {
     const url = (n) => (n === 1) ? `/archive/${tag}/` : `/archive/${tag}/${n}/`;
-    const pages = search.pages(`type=post '${tag}'`);
+    const pages = search.pages(`type=post '${tag}'`, "date=desc");
 
     for (const page of paginate(pages, { url, size: 10 })) {
       yield {

--- a/deno.json
+++ b/deno.json
@@ -1,9 +1,9 @@
 {
   "imports": {
     "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.3/",
-    "blog/": "https://deno.land/x/lume_theme_simple_blog@v1.16.2/",
     "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.14.4/",
-    "lume/jsx-runtime": "https://cdn.jsdelivr.net/gh/oscarotero/ssx@0.1.14/jsx-runtime.ts"
+    "lume/jsx-runtime": "https://cdn.jsdelivr.net/gh/oscarotero/ssx@0.1.14/jsx-runtime.ts",
+    "lume/markdown-plugins/": "https://cdn.jsdelivr.net/gh/lumeland/markdown-plugins@0.10.0/"
   },
   "tasks": {
     "lume": {

--- a/plugins.ts
+++ b/plugins.ts
@@ -19,9 +19,9 @@ import slugifyUrls from "lume/plugins/slugify_urls.ts";
    rainbow mode JS when that lands, .use() commented out below as well */
 // import terser from "lume/plugins/terser.ts";
 // lumeland/markdown-plugins
-import footnotes from "https://cdn.jsdelivr.net/gh/lumeland/markdown-plugins@0.10.0/footnotes.ts";
-import image from "https://cdn.jsdelivr.net/gh/lumeland/markdown-plugins@0.10.0/image.ts";
-import toc from "https://cdn.jsdelivr.net/gh/lumeland/markdown-plugins@0.10.0/toc.ts";
+import footnotes from "lume/markdown-plugins/footnotes.ts";
+import image from "lume/markdown-plugins/image.ts";
+import toc from "lume/markdown-plugins/toc.ts";
 // https://github.com/mdit-plugins/mdit-plugins
 // docs https://mdit-plugins.github.io/alert.html
 import { alert } from "https://cdn.jsdelivr.net/npm/@mdit/plugin-alert@0.22.3/lib/index.js";

--- a/posts/2025-12-solstice.md
+++ b/posts/2025-12-solstice.md
@@ -1,13 +1,18 @@
 ---
 date: "2025-12-21T15:03Z"
 author: Ricky de Laveaga
+tags:
+  - Date
+  - Front Matter
+  - Lume
+  - Xeo
 ---
 
 This post only has the title in the filename, `2025-12-solstice.md`. Because the
 partial date is incomplete and does not have a day value, it gets parsed as part
 of the title. The `date` (as `2025-12-21T15:03Z`, the
 [2025 December Solstice](https://earthsky.org/astronomy-essentials/everything-you-need-to-know-december-solstice/))
-and author are in
+the `author`, and the `tags` are in
 [front matter](https://lume.land/docs/getting-started/page-data/), but there is
 no need to put a `title`, thanks to
 [Lume’s Extract date plugin](https://lume.land/plugins/extract_date/).

--- a/posts/2161-01-16-13-00-00-stardate-foundation.md
+++ b/posts/2161-01-16-13-00-00-stardate-foundation.md
@@ -1,11 +1,17 @@
 ---
 author: Ricky de Laveaga
+tags:
+  - Date
+  - Front Matter
+  - Lume
+  - Star Trek
+  - Title
 draft: true
 ---
 
-A post where all we have is `draft` set to true and the `author` in the
-[front matter](https://lume.land/docs/getting-started/page-data/). The `date`
-and `title` get set by
+A post where all we have is the `author`, the `tags`, and `draft` set to true in
+the [front matter](https://lume.land/docs/getting-started/page-data/). The
+`date` and `title` get set by
 [Lume’s Extract date plugin](https://lume.land/plugins/extract_date/) from the
 filename, (`2161-01-16-13-00-00-stardate-foundation.md`).
 

--- a/posts/differences.md
+++ b/posts/differences.md
@@ -3,7 +3,11 @@ title: Differences between Xeo and Simple Blog
 date: "2025-12-31T13:00Z"
 author: Ricky de Laveaga
 tags:
+  - Date
   - Design
+  - Front Matter
+  - Lume
+  - Title
   - Xeo
 draft: false
 ---

--- a/posts/no-title/index.md
+++ b/posts/no-title/index.md
@@ -1,9 +1,12 @@
 ---
 date: "2025-01-01T13:00Z"
 author: Ricky de Laveaga
+tags:
+  - Front Matter
+  - Title
 ---
 
-A post with `date` and `author` in the
+A post with `date`, `author`, and `tags` in the
 [front matter](https://lume.land/docs/getting-started/page-data/), but no title.
 The source file named `index.md` is inside a folder named `no-title`. The
 [`basename`](https://lume.land/docs/creating-pages/urls/#basename) gets


### PR DESCRIPTION
- rm vestigial `blog` import
- appease [`no-import-prefix`](https://docs.deno.com/lint/rules/no-import-prefix/)
  + declared `lume/markdown-plugins` dependencies in `deno.json`