### PR TITLE
fix: rm `lume/` from `markdown-plugins` prefix

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,7 @@
     "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.3/",
     "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.14.4/",
     "lume/jsx-runtime": "https://cdn.jsdelivr.net/gh/oscarotero/ssx@0.1.14/jsx-runtime.ts",
-    "lume/markdown-plugins/": "https://cdn.jsdelivr.net/gh/lumeland/markdown-plugins@0.10.0/"
+    "markdown-plugins/": "https://cdn.jsdelivr.net/gh/lumeland/markdown-plugins@0.10.0/"
   },
   "tasks": {
     "lume": {

--- a/plugins.ts
+++ b/plugins.ts
@@ -19,9 +19,9 @@ import slugifyUrls from "lume/plugins/slugify_urls.ts";
    rainbow mode JS when that lands, .use() commented out below as well */
 // import terser from "lume/plugins/terser.ts";
 // lumeland/markdown-plugins
-import footnotes from "lume/markdown-plugins/footnotes.ts";
-import image from "lume/markdown-plugins/image.ts";
-import toc from "lume/markdown-plugins/toc.ts";
+import footnotes from "markdown-plugins/footnotes.ts";
+import image from "markdown-plugins/image.ts";
+import toc from "markdown-plugins/toc.ts";
 // https://github.com/mdit-plugins/mdit-plugins
 // docs https://mdit-plugins.github.io/alert.html
 import { alert } from "https://cdn.jsdelivr.net/npm/@mdit/plugin-alert@0.22.3/lib/index.js";


### PR DESCRIPTION
- `lume/markdown-plugins` worked locally but failed CI changed to `markdown-plugins` to avoid confusion with main lume module breaking builds

```
error: Uncaught (in promise) TypeError: Module not found
"https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.3/markdown-plugins/footnotes.ts".
at https://deno.land/x/xeo@v7.0.1/plugins.ts:22:23
```